### PR TITLE
fix: Download the latest mactex explicitly instead of a specific version

### DIFF
--- a/Scripts/setup-mac
+++ b/Scripts/setup-mac
@@ -21,7 +21,7 @@ brew install node
 ## For testing with lit
 brew install python3
 ## To build DafnyRef.pdf
-brew install --cask basictex
+brew install --cask https://mirror.mwt.me/ctan/systems/mac/mactex/BasicTeX.pkg
 brew install pandoc
 eval "$(/usr/libexec/path_helper)"
 sudo tlmgr update --self


### PR DESCRIPTION
Fixes #

<!-- Is this a user-visible change?  Remember to update RELEASE_NOTES.md -->

<!-- Is this a bug fix?  Remember to include a test in Test/git-issues/ -->

<!-- Does this PR need tests?  Add them to `Test/` or to `Source/*.Test/…` and run them with `dotnet test` -->

<small>By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT license](https://github.com/dafny-lang/dafny/blob/master/LICENSE.txt).</small>
